### PR TITLE
Fix check style configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ Static code analysis rules are defined in file `./config/checkstyle/checkstyle.x
 in Intellij Idea IDE following steps are recommended:
 1) Install checkstyle plugin CheckStyle-IDEA
 2) Import the file into project checkstyle scheme using 
-`Settings/Editor/Code Style/Java/Import Scheme/Checkstyle configuration`.
-3) Configure the plugin by adding `checkstyle.xml` into  `Settings/Other Settings/Checkstyle/Configuration file`
+`Settings/Editor/Code Style/Java/Scheme/Import Scheme/Checkstyle configuration`.
+3) Configure the plugin by adding `checkstyle.xml` into `Settings/Tools/Checkstyle/Configuration file`
  
 -----
 Tento repozitář vznikl v rámci projektu OPZ č. [CZ.03.4.74/0.0/0.0/15_025/0013983](https://esf2014.esfcr.cz/PublicPortal/Views/Projekty/Public/ProjektDetailPublicPage.aspx?action=get&datovySkladId=F5E162B2-15EC-4BBE-9ABD-066388F3D412).

--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ To manage source code it is recommended to install plugins:
  
 Static code analysis rules are defined in file `./config/checkstyle/checkstyle.xml`. In order to set up this checkstyle
 in Intellij Idea IDE following steps are recommended:
-1) Import the file into project checkstyle scheme using 
+1) Install checkstyle plugin CheckStyle-IDEA
+2) Import the file into project checkstyle scheme using 
 `Settings/Editor/Code Style/Java/Import Scheme/Checkstyle configuration`.
-2) Install checkstyle plugin CheckStyle-IDEA
 3) Configure the plugin by adding `checkstyle.xml` into  `Settings/Other Settings/Checkstyle/Configuration file`
  
 -----

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ gradleLint {
 }
 
 quality {
-    checkstyleVersion = '8.32'
+    checkstyleVersion = '9.2'
     checkstyle = true
     spotbugs = false
     pmd = false

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -297,7 +297,7 @@
                       value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
         </module>
         <module name="JavadocMethod">
-            <property name="scope" value="public"/>
+            <property name="accessModifiers" value="public"/>
             <property name="allowMissingParamTags" value="true"/>
             <property name="allowMissingReturnTag" value="true"/>
             <property name="allowedAnnotations" value="Override, Test"/>


### PR DESCRIPTION
@psiotwo @karelklima 

When I set up sgov project from the scratch in Intellij Idea, the checkstyle plugin did not work there due to old format of `checkstyle.xml`. You would have to downgrade checkstyle version to older one ....


Thus, instead of extending instructions in README.md, I migrated the file from version 8.32 --> 9.2. **If you have your IDE set up already for the sgov server, please reset your settings of the checkstyle plugin. This means just changing version of checkstyle within the plugin to the newest version.**

 
![image](https://user-images.githubusercontent.com/3962237/149488395-513f7f54-3803-4243-8275-a6e5507de8da.png)


