### PR TITLE
[#121] Support one vocabulary in multiple workspaces

### DIFF
--- a/src/main/java/com/github/sgov/server/controller/WorkspaceController.java
+++ b/src/main/java/com/github/sgov/server/controller/WorkspaceController.java
@@ -195,20 +195,6 @@ public class WorkspaceController extends BaseController {
         return workspaceService.getDependentsForVocabularyInWorkspace(workspaceId, vocabularyId);
     }
 
-    private void checkNotLoaded(final URI workspaceUri, final URI vocabularyUri) {
-        final Collection<Workspace> wss = workspaceService
-            .getWorkspacesWithReadWriteVocabulary(vocabularyUri)
-            .stream()
-            .filter(ws -> !ws.getUri().equals(workspaceUri))
-            .collect(Collectors.toSet());
-
-        if (!wss.isEmpty()) {
-            throw VocabularyRegisteredinReadWriteException.create(vocabularyUri.toString(),
-                wss.stream()
-                    .map(Asset::getUri).collect(Collectors.toList())
-            );
-        }
-    }
 
     /**
      * Adds a vocabulary to a workspace.
@@ -236,8 +222,6 @@ public class WorkspaceController extends BaseController {
     ) {
         final URI workspaceUri = resolveIdentifier(
             namespace, workspaceFragment, Vocabulary.s_c_metadatovy_kontext);
-
-        checkNotLoaded(workspaceUri, vocabularyUri);
 
         final URI vocabularyContextUri =
             workspaceService.ensureVocabularyExistsInWorkspace(
@@ -276,8 +260,6 @@ public class WorkspaceController extends BaseController {
     ) {
         final URI workspaceUri = resolveIdentifier(
             namespace, workspaceFragment, Vocabulary.s_c_metadatovy_kontext);
-
-        checkNotLoaded(workspaceUri, vocabularyContext.getBasedOnVersion());
 
         final URI vocabularyContextUri =
             workspaceService.ensureVocabularyExistsInWorkspace(

--- a/src/main/java/com/github/sgov/server/service/WorkspaceService.java
+++ b/src/main/java/com/github/sgov/server/service/WorkspaceService.java
@@ -90,10 +90,8 @@ public class WorkspaceService {
     /**
      * Ensures that a vocabulary with the given IRI is registered in the workspace. - If the
      * vocabulary does not exist, an error is thrown. - if the vocabulary exists and is part of the
-     * workspace, nothing happens, and the content is left intact. - if the vocabulary exists, is
-     * NOT part of the workspace, and should be added as R/W it is only added to the workspace if no
-     * other workspace is registering the vocabulary in R/W. - if the vocabulary exists and is NOT
-     * part of the workspace, it is added to the workspace and its content is loaded.
+     * workspace, nothing happens, and the content is left intact. - if the vocabulary exists
+     * and is NOT part of the workspace, it is added to the workspace and its content is loaded.
      *
      * @param workspaceUri  URI of the workspace to connect the vocabulary context to.
      * @param vocabularyContextDto vocabulary metadata
@@ -109,18 +107,10 @@ public class WorkspaceService {
             return vocabularyContextUri;
         }
 
-        if (vocabularyService.getVocabulariesAsContextDtos().stream()
-            .noneMatch(vc ->
-                vc.getBasedOnVersion().equals(vocabularyUri)
-            )
-        ) {
-            if (vocabularyContextDto.getLabel() == null) {
-                throw NotFoundException.create("Vocabulary", vocabularyUri);
-            }
-            return createVocabularyContext(workspace, vocabularyContextDto);
-        } else {
-            return loadVocabularyContextFromCache(workspace, vocabularyUri);
+        if (vocabularyContextDto.getLabel() == null) {
+            throw NotFoundException.create("Vocabulary", vocabularyUri);
         }
+        return createVocabularyContext(workspace, vocabularyContextDto);
     }
 
     private URI createVocabularyContext(Workspace workspace,


### PR DESCRIPTION
@psiotwo 

Not very sure about changing the implementation in `WorkspaceService.ensureVocabularyExistsInWorkspace()`. Might have some misunderstanding of how R/W and R/O vocabularies works/should be used within the workspace.

I assume that:
1) every vocabulary added to a workspace by `/{workspaceFragment}/vocabularies-full` endpoint should be R/W
2) `createVocabularyContext(workspace, vocabularyContextDto)` method call returns reference to what you call R/W vocabulary
3) `loadVocabularyContextFromCache(workspace, vocabularyUri)` method call returns reference to what you call R/O vocabulary