### PR TITLE
[#131] Do not allow to create 2 vocabs with same IRI if not published

### DIFF
--- a/src/main/java/com/github/sgov/server/controller/VocabularyController.java
+++ b/src/main/java/com/github/sgov/server/controller/VocabularyController.java
@@ -1,6 +1,7 @@
 package com.github.sgov.server.controller;
 
 import com.github.sgov.server.controller.dto.VocabularyDto;
+import com.github.sgov.server.controller.dto.VocabularyStatusDto;
 import com.github.sgov.server.service.repository.VocabularyRepositoryService;
 import com.github.sgov.server.util.Constants;
 import cz.cvut.kbss.jsonld.JsonLd;
@@ -46,6 +47,29 @@ public class VocabularyController extends BaseController {
         final String lang;
         lang = headers.getOrDefault("Accept-Language", "cs");
         return vocabularyService.getVocabulariesAsContextDtos(lang);
+    }
+
+    /**
+     * Retrieve vocabulary status, i.e. information whether this vocabulary was
+     * published or edited in a workspace.
+     *
+     * @param vocabularyFragment local name of vocabulary id.
+     * @param namespace          Namespace used for resource identifier resolution. Optional, if not
+     *                           specified, the configured namespace is used.
+     * @return Workspace specified by workspaceFragment and optionally namespace.
+     */
+    @GetMapping(value = "/vocabulary-status/{vocabularyFragment}",
+        produces = {
+            MediaType.APPLICATION_JSON_VALUE,
+            JsonLd.MEDIA_TYPE})
+    @ApiOperation(value = "Get vocabulary status.")
+    public VocabularyStatusDto getVocabularyStatus(
+        @PathVariable String vocabularyFragment,
+        @RequestParam(name = Constants.QueryParams.NAMESPACE) String namespace) {
+
+        final URI identifier = resolveIdentifier(
+            namespace, vocabularyFragment, null);
+        return vocabularyService.getVocabularyStatus(identifier);
     }
 
     /**

--- a/src/main/java/com/github/sgov/server/controller/WorkspaceController.java
+++ b/src/main/java/com/github/sgov/server/controller/WorkspaceController.java
@@ -1,8 +1,6 @@
 package com.github.sgov.server.controller;
 
 import com.github.sgov.server.controller.dto.VocabularyContextDto;
-import com.github.sgov.server.exception.VocabularyRegisteredinReadWriteException;
-import com.github.sgov.server.model.Asset;
 import com.github.sgov.server.model.VocabularyContext;
 import com.github.sgov.server.model.Workspace;
 import com.github.sgov.server.service.WorkspacePublicationService;
@@ -15,10 +13,8 @@ import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import java.net.URI;
-import java.util.Collection;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -212,8 +208,8 @@ public class WorkspaceController extends BaseController {
     @Deprecated
     @PostMapping(value = "/{workspaceFragment}/vocabularies")
     @ApiOperation(value =
-        "Create vocabulary context within workspace. If label is provided, a new vocabulary is "
-            + "created if not found.")
+        "Create vocabulary context within workspace. A new vocabulary is created "
+            + "if not found and in this case label is required.")
     public ResponseEntity<String> addVocabularyToWorkspace(
         @PathVariable String workspaceFragment,
         @RequestParam(name = QueryParams.NAMESPACE, required = false) String namespace,
@@ -251,8 +247,8 @@ public class WorkspaceController extends BaseController {
      */
     @PostMapping(value = "/{workspaceFragment}/vocabularies-full")
     @ApiOperation(value =
-        "Create vocabulary context within workspace. If label is provided, a new vocabulary is "
-            + "created if not found.")
+        "Create vocabulary context within workspace. A new vocabulary is created "
+            + "if not found and in this case label is required.")
     public ResponseEntity<String> addVocabularyToWorkspace(
         @PathVariable String workspaceFragment,
         @RequestParam(name = QueryParams.NAMESPACE, required = false) String namespace,

--- a/src/main/java/com/github/sgov/server/controller/dto/VocabularyStatusDto.java
+++ b/src/main/java/com/github/sgov/server/controller/dto/VocabularyStatusDto.java
@@ -1,0 +1,16 @@
+package com.github.sgov.server.controller.dto;
+
+import cz.cvut.kbss.jsonld.annotation.JsonLdAttributeOrder;
+import lombok.Data;
+
+@Data
+@JsonLdAttributeOrder({"published", "edited"})
+public class VocabularyStatusDto {
+    private boolean published;
+    private boolean edited;
+
+    public VocabularyStatusDto(boolean vocabularyPublished, boolean vocabularyEdited) {
+        this.published = vocabularyPublished;
+        this.edited = vocabularyEdited;
+    }
+}

--- a/src/main/java/com/github/sgov/server/service/WorkspaceService.java
+++ b/src/main/java/com/github/sgov/server/service/WorkspaceService.java
@@ -88,14 +88,14 @@ public class WorkspaceService {
     }
 
     /**
-     * Ensures that a vocabulary with the given IRI is registered in the workspace. - If the
-     * vocabulary does not exist, an error is thrown. - if the vocabulary exists and is part of the
-     * workspace, nothing happens, and the content is left intact. - if the vocabulary exists, is
-     * NOT part of the workspace, and should be added as R/W it is only added to the workspace if no
-     * other workspace is registering the vocabulary in R/W. - if the vocabulary exists and is NOT
-     * part of the workspace, it is added to the workspace and its content is loaded.
+     * Ensures that a vocabulary with the given IRI is registered in the given workspace.
+     * The vocabulary is registered by first of the following actions that matches:
+     * 1) if vocabulary is already in workspace return it intact
+     * 2) if vocabulary exists, add it to workspace and load its content
+     * 3) create new vocabulary in the workspace (unless there is same vocabulary in other
+     * workspace or label of the vocabulary is not provided)
      *
-     * @param workspaceUri  URI of the workspace to connect the vocabulary context to.
+     * @param workspaceUri         URI of the workspace to connect the vocabulary context to.
      * @param vocabularyContextDto vocabulary metadata
      * @return URI of the vocabulary context to create
      */
@@ -117,6 +117,7 @@ public class WorkspaceService {
             if (vocabularyContextDto.getLabel() == null) {
                 throw NotFoundException.create("Vocabulary", vocabularyUri);
             }
+            vocabularyService.verifyVocabularyNotInAnyWorkspace(vocabularyUri);
             return createVocabularyContext(workspace, vocabularyContextDto);
         } else {
             return loadVocabularyContextFromCache(workspace, vocabularyUri);

--- a/src/main/java/com/github/sgov/server/service/repository/VocabularyRepositoryService.java
+++ b/src/main/java/com/github/sgov/server/service/repository/VocabularyRepositoryService.java
@@ -10,7 +10,6 @@ import com.github.sgov.server.dao.WorkspaceDao;
 import com.github.sgov.server.exception.SGoVException;
 import com.github.sgov.server.model.TrackableContext;
 import com.github.sgov.server.model.VocabularyContext;
-import com.github.sgov.server.model.Workspace;
 import com.github.sgov.server.util.IdnUtils;
 import com.github.sgov.server.util.Vocabulary;
 import com.github.sgov.server.util.VocabularyCreationHelper;
@@ -40,7 +39,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
- * Service to managed workspaces.
+ * Service to managed vocabularies.
  */
 @Service
 public class VocabularyRepositoryService extends BaseRepositoryService<VocabularyContext> {
@@ -147,6 +146,24 @@ public class VocabularyRepositoryService extends BaseRepositoryService<Vocabular
     }
 
     /**
+     * Verifies that given vocabulary is not part of any workspace.
+     *
+     * @param vocabularyUri Uri of the vocabulary.
+     */
+    public void verifyVocabularyNotInAnyWorkspace(URI vocabularyUri) {
+        this.findAll().stream().filter(
+            vc -> vc.getBasedOnVersion().equals(vocabularyUri)
+        ).findAny().ifPresent(
+            vc -> {
+                throw new SGoVException(String.format(
+                    "Vocabulary %s already exists in a workspace within context %s.",
+                    vocabularyUri,
+                    vc.getUri()));
+            }
+        );
+    }
+
+    /**
      * Reloads the given vocabulary context from the source endpoint.
      *
      * @param uri the context to be populated.
@@ -240,7 +257,7 @@ public class VocabularyRepositoryService extends BaseRepositoryService<Vocabular
                 + "/> CONSTRUCT {?s ?p ?o} WHERE { GRAPH ?g {?s ?p ?o} FILTER(?g IN (<"
                 + version
                 + ">" + ((context instanceof VocabularyContext)
-                    ? ",:glosář,:model,:mapování,:přílohy" : "")
+                ? ",:glosář,:model,:mapování,:přílohy" : "")
                 + "))}");
         return query.evaluate();
     }

--- a/src/main/java/com/github/sgov/server/service/repository/VocabularyRepositoryService.java
+++ b/src/main/java/com/github/sgov/server/service/repository/VocabularyRepositoryService.java
@@ -5,6 +5,7 @@ import static com.github.sgov.server.util.Constants.SERIALIZATION_LANGUAGE;
 import com.github.sgov.server.config.conf.RepositoryConf;
 import com.github.sgov.server.controller.dto.VocabularyContextDto;
 import com.github.sgov.server.controller.dto.VocabularyDto;
+import com.github.sgov.server.controller.dto.VocabularyStatusDto;
 import com.github.sgov.server.dao.VocabularyDao;
 import com.github.sgov.server.dao.WorkspaceDao;
 import com.github.sgov.server.exception.SGoVException;
@@ -160,6 +161,57 @@ public class VocabularyRepositoryService extends BaseRepositoryService<Vocabular
                     vocabularyUri,
                     vc.getUri()));
             }
+        );
+    }
+
+    /**
+     * Retrieve vocabulary status, i.e. information whether this vocabulary was
+     * published or edited in a workspace.
+     *
+     * @param vocabularyUri Uri of the vocabulary.
+     * @return vocabulary status
+     */
+    public VocabularyStatusDto getVocabularyStatus(URI vocabularyUri) {
+        return new VocabularyStatusDto(
+            isVocabularyPublished(vocabularyUri),
+            existsInAWorkspace(vocabularyUri)
+        );
+
+    }
+
+    /**
+     * Verifies that given vocabulary is not published.
+     * @param vocabularyUri Uri of the vocabulary.
+     */
+    public void verifyVocabularyNotPublished(URI vocabularyUri) {
+        if (isVocabularyPublished(vocabularyUri)) {
+            throw new SGoVException(String.format(
+                "Vocabulary %s already exists in a workspace.",
+                vocabularyUri));
+        }
+    }
+
+    /**
+     * Tests is given vocabulary exists in a workspace.
+     *
+     * @param vocabularyUri Uri of the vocabulary.
+     * @return True if the vocabulary exists in a workspace.
+     */
+    private boolean existsInAWorkspace(URI vocabularyUri) {
+        return this.findAll().stream().anyMatch(
+            vc -> vc.getBasedOnVersion().equals(vocabularyUri)
+        );
+    }
+
+    /**
+     * Tests is given vocabulary is published.
+     *
+     * @param vocabularyUri Uri of the vocabulary.
+     * @return True if the vocabulary is published.
+     */
+    private boolean isVocabularyPublished(URI vocabularyUri) {
+        return getVocabulariesAsContextDtos(null).stream().anyMatch(
+            v -> v.getBasedOnVersion().equals(vocabularyUri)
         );
     }
 


### PR DESCRIPTION
@klimakarel

There should be two actions following this merge:
1) Control Panel should be changed to not allow to create of vocabularies that are not published but exist in a different workspace 
- I assume you can get this information from GET /workspaces. This REST API is quite appropriate as it provides you also information about a workspace in which the vocabulary exists. In case you would like me to implement additional REST endpoint let me know.
I mean to implement additional error handling here :
![image](https://user-images.githubusercontent.com/3962237/167131953-3667c92a-4274-432e-ba3d-4802be86a30f.png)
The only difference is that we want to say the error message "Vocabulary with this IRI is already part of workspace XXXX"

2) Consider migrating to newer API created by PK, i.e. from /vocabularies to /vocabularies-full  (so we clean up some code)
```
@Deprecated
/{workspaceFragment}/vocabularies
```
```
/{workspaceFragment}/vocabularies-full
```
see [WorkspaceController.java](https://github.com/opendata-mvcr/sgov/blob/main/src/main/java/com/github/sgov/server/controller/WorkspaceController.java).