### PR TITLE
Change namespace of příloha to slovnik.gov.cz

### DIFF
--- a/src/main/java/com/github/sgov/server/util/Vocabulary.java
+++ b/src/main/java/com/github/sgov/server/util/Vocabulary.java
@@ -71,7 +71,7 @@ public final class Vocabulary {
     public static final String s_p_ma_model = DATA_DESCRIPTION_NAMESPACE + "má-model";
     public static final String s_c_glosar = DATA_DESCRIPTION_NAMESPACE + "glosář";
     public static final String s_c_model = DATA_DESCRIPTION_NAMESPACE + "model";
-    public static final String s_c_priloha = DATA_DESCRIPTION_NAMESPACE + "příloha";
+    public static final String s_c_priloha = SLOVNIK_GOV_CZ + "/příloha";
 
     private Vocabulary() {
     }


### PR DESCRIPTION
Changes attachment namespace according to [SSP PR #447](https://github.com/opendata-mvcr/ssp/pull/477).