### PR TITLE
[New] Do not publish empty attachments reference file

### DIFF
--- a/src/main/java/com/github/sgov/server/service/WorkspacePublicationService.java
+++ b/src/main/java/com/github/sgov/server/service/WorkspacePublicationService.java
@@ -123,7 +123,7 @@ public class WorkspacePublicationService {
                 publicationService.storeContext(c, folder);
                 githubService.commit(git, MessageFormat.format(
                     "Publishing vocabulary {0} in workspace {1} ({2})", iri,
-                    workspace.getLabel(), workspace.getUri().toString()));
+                    workspace.getLabel(), workspace.getUri()));
             } catch (IllegalArgumentException e) {
                 throw new PublicationException("Invalid vocabulary IRI " + iri);
             }
@@ -140,7 +140,7 @@ public class WorkspacePublicationService {
                 publicationService.storeContext(c, folder);
                 githubService.commit(git, MessageFormat.format(
                     "Publishing attachment {0} in workspace {1} ({2})", iri,
-                    workspace.getLabel(), workspace.getUri().toString()));
+                    workspace.getLabel(), workspace.getUri()));
             } catch (IllegalArgumentException e) {
                 throw new PublicationException("Invalid vocabulary IRI " + iri);
             }

--- a/src/main/java/com/github/sgov/server/service/repository/GitPublicationService.java
+++ b/src/main/java/com/github/sgov/server/service/repository/GitPublicationService.java
@@ -173,14 +173,12 @@ public class GitPublicationService {
 
             folder.getFolder().mkdirs();
 
-            conGitSsp.export(getDeterministicWriter(new FileWriter(folder.getVocabularyFile())),
-                ctxVocabulary);
-            conGitSsp.export(getDeterministicWriter(new FileWriter(folder.getGlossaryFile())),
-                ctxGlossary);
-            conGitSsp.export(getDeterministicWriter(new FileWriter(folder.getModelFile())),
-                ctxModel);
-            conGitSsp.export(getDeterministicWriter(new FileWriter(folder.getAttachmentsFile())),
-                ctxAttachments);
+            saveContextToFile(conGitSsp, ctxVocabulary, folder.getVocabularyFile());
+            saveContextToFile(conGitSsp, ctxGlossary, folder.getGlossaryFile());
+            saveContextToFile(conGitSsp, ctxModel, folder.getModelFile());
+            if (! context.getAttachments().isEmpty()) {
+                saveContextToFile(conGitSsp, ctxAttachments, folder.getAttachmentsFile());
+            }
 
             conGitSsp.close();
             cWorkspaceRepo.close();
@@ -245,5 +243,15 @@ public class GitPublicationService {
         addNamespaces(conGitSsp);
 
         return conGitSsp;
+    }
+
+    private void saveContextToFile(
+                                   RepositoryConnection inputRdf4RepositoryConnection,
+                                   IRI inputDataContext,
+                                   File outputFile
+                                   ) throws IOException {
+        inputRdf4RepositoryConnection.export(
+            getDeterministicWriter(new FileWriter(outputFile)),
+            inputDataContext);
     }
 }


### PR DESCRIPTION
Pull request ensures that *-prilohy.ttl file is never committed into SSP as empty file. 

Tested on https://github.com/opendata-mvcr/ssp/pull/516 .
Validation of this behavior in SSP was pushed into https://github.com/opendata-mvcr/ssp/pull/512.