### PR TITLE
Create change tracking context in new graph

### DIFF
--- a/src/main/java/com/github/sgov/server/model/VocabularyContext.java
+++ b/src/main/java/com/github/sgov/server/model/VocabularyContext.java
@@ -21,7 +21,7 @@ public class VocabularyContext extends TrackableContext {
 
     @ParticipationConstraints(nonEmpty = true)
     @OWLObjectProperty(iri = Vocabulary.s_p_ma_kontext_sledovani_zmen,
-        cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REMOVE},
+        cascade = {CascadeType.PERSIST, CascadeType.REMOVE},
         fetch = FetchType.EAGER)
     private ChangeTrackingContext changeTrackingContext;
 

--- a/src/main/java/com/github/sgov/server/model/util/DescriptorFactory.java
+++ b/src/main/java/com/github/sgov/server/model/util/DescriptorFactory.java
@@ -53,8 +53,8 @@ public final class DescriptorFactory {
      * <p>The descriptor specifies that the instance context will correspond to the given IRI.
      * It also initializes other required attribute descriptors.
      *
-     * @param vocabularyContextUri     Vocabulary context identifier for which the descriptor should be
-     *                                 created
+     * @param vocabularyContextUri     Vocabulary context identifier for which the descriptor should
+     *                                 be created
      * @param changeTrackingContextUri Change tracking context of given vocabulary
      * @return Vocabulary context descriptor
      */

--- a/src/main/java/com/github/sgov/server/model/util/DescriptorFactory.java
+++ b/src/main/java/com/github/sgov/server/model/util/DescriptorFactory.java
@@ -43,7 +43,8 @@ public final class DescriptorFactory {
      */
     public Descriptor vocabularyDescriptor(VocabularyContext vocabularyContext) {
         Objects.requireNonNull(vocabularyContext);
-        return vocabularyDescriptor(vocabularyContext.getUri());
+        return vocabularyDescriptor(vocabularyContext.getUri(),
+            vocabularyContext.getChangeTrackingContext().getUri());
     }
 
     /**
@@ -52,15 +53,19 @@ public final class DescriptorFactory {
      * <p>The descriptor specifies that the instance context will correspond to the given IRI.
      * It also initializes other required attribute descriptors.
      *
-     * @param vocabularyContextUri Vocabulary context identifier for which the descriptor should be
-     *                             created
+     * @param vocabularyContextUri     Vocabulary context identifier for which the descriptor should be
+     *                                 created
+     * @param changeTrackingContextUri Change tracking context of given vocabulary
      * @return Vocabulary context descriptor
      */
-    public Descriptor vocabularyDescriptor(URI vocabularyContextUri) {
+    public Descriptor vocabularyDescriptor(URI vocabularyContextUri, URI changeTrackingContextUri) {
         Objects.requireNonNull(vocabularyContextUri);
         EntityDescriptor descriptor = assetDescriptor(vocabularyContextUri);
         descriptor.addAttributeDescriptor(fieldSpec(VocabularyContext.class, "attachmentContexts"),
             new EntityDescriptor((URI) null));
+        descriptor.addAttributeDescriptor(
+            fieldSpec(VocabularyContext.class, "changeTrackingContext"),
+            new EntityDescriptor(changeTrackingContextUri));
         return descriptor;
     }
 


### PR DESCRIPTION
For the new KODIfied TermIt, it is necessary to create Change tracking context in a new graph in DB. This context will also be used to track changes made in OG.