### PR TITLE
Remove application contexts when removing vocabulary fix

### DIFF
--- a/src/main/java/com/github/sgov/server/dao/VocabularyDao.java
+++ b/src/main/java/com/github/sgov/server/dao/VocabularyDao.java
@@ -3,6 +3,7 @@ package com.github.sgov.server.dao;
 import com.github.sgov.server.exception.PersistenceException;
 import com.github.sgov.server.model.VocabularyContext;
 import com.github.sgov.server.model.util.DescriptorFactory;
+import com.github.sgov.server.util.Vocabulary;
 import cz.cvut.kbss.jopa.model.EntityManager;
 import java.net.URI;
 import java.util.Objects;
@@ -64,5 +65,18 @@ public class VocabularyDao extends BaseDao<VocabularyContext> {
         } catch (RuntimeException e) {
             throw new PersistenceException(e);
         }
+    }
+
+    /**
+     * Clears all application contexts for the given vocabulary context.
+     *
+     * @param vocabularyContextUri vocabulary context URI
+     */
+    public void clearApplicationContexts(URI vocabularyContextUri) {
+        em.createNativeQuery("SELECT ?o WHERE { GRAPH ?g { ?s ?p ?o } . }", URI.class)
+            .setParameter("g", vocabularyContextUri)
+            .setParameter("s", vocabularyContextUri)
+            .setParameter("p", URI.create(Vocabulary.s_p_ma_aplikacni_kontext))
+            .getResultList().forEach(this::clearContext);
     }
 }

--- a/src/main/java/com/github/sgov/server/model/VocabularyContext.java
+++ b/src/main/java/com/github/sgov/server/model/VocabularyContext.java
@@ -26,12 +26,6 @@ public class VocabularyContext extends TrackableContext {
     private ChangeTrackingContext changeTrackingContext;
 
     @ParticipationConstraints
-    @OWLObjectProperty(iri = Vocabulary.s_p_ma_aplikacni_kontext,
-        cascade = {CascadeType.REMOVE},
-        fetch = FetchType.EAGER)
-    private Set<URI> applicationContexts = new HashSet<>();
-
-    @ParticipationConstraints
     @OWLObjectProperty(iri = Vocabulary.s_p_ma_prilohu,
         cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REMOVE},
         fetch = FetchType.EAGER)

--- a/src/main/java/com/github/sgov/server/service/repository/VocabularyRepositoryService.java
+++ b/src/main/java/com/github/sgov/server/service/repository/VocabularyRepositoryService.java
@@ -350,7 +350,7 @@ public class VocabularyRepositoryService extends BaseRepositoryService<Vocabular
     public void remove(VocabularyContext instance) {
         removeAllAttachments(instance);
         clearContext(instance.getChangeTrackingContext().getUri());
-        clearApplicationContexts(instance);
+        vocabularyDao.clearApplicationContexts(instance.getUri());
         super.remove(instance);
         clearContext(instance.getUri());
     }
@@ -361,9 +361,5 @@ public class VocabularyRepositoryService extends BaseRepositoryService<Vocabular
 
     private void removeAllAttachments(VocabularyContext vocabularyContext) {
         vocabularyContext.getAttachmentContexts().forEach(attachmentRepositoryService::remove);
-    }
-
-    private void clearApplicationContexts(VocabularyContext vocabularyContext) {
-        vocabularyDao.clearApplicationContexts(vocabularyContext.getUri());
     }
 }

--- a/src/main/java/com/github/sgov/server/service/repository/VocabularyRepositoryService.java
+++ b/src/main/java/com/github/sgov/server/service/repository/VocabularyRepositoryService.java
@@ -364,6 +364,6 @@ public class VocabularyRepositoryService extends BaseRepositoryService<Vocabular
     }
 
     private void clearApplicationContexts(VocabularyContext vocabularyContext) {
-        vocabularyContext.getApplicationContexts().forEach(this::clearContext);
+        vocabularyDao.clearApplicationContexts(vocabularyContext.getUri());
     }
 }

--- a/src/main/java/com/github/sgov/server/service/repository/VocabularyRepositoryService.java
+++ b/src/main/java/com/github/sgov/server/service/repository/VocabularyRepositoryService.java
@@ -350,8 +350,8 @@ public class VocabularyRepositoryService extends BaseRepositoryService<Vocabular
     public void remove(VocabularyContext instance) {
         removeAllAttachments(instance);
         clearContext(instance.getChangeTrackingContext().getUri());
-        super.remove(instance);
         clearApplicationContexts(instance);
+        super.remove(instance);
         clearContext(instance.getUri());
     }
 


### PR DESCRIPTION
Because I only tested #158 with Postman requests to SGOV running in IDE, I was not aware that when it built into a docker image, it won't work sometimes. Found out that when built as a docker image fetching the `applicationContexts` property in the `VocabularyContext` class, most of the time returned an empty list (despite working fine when running in IDE).

This PR fixes that by fetching application contexts by a native query. I tested it locally on my docker instance of the Assembly line.

Related #157 