### PR TITLE
Changing DTO when fetching all vocabularies

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -19,6 +19,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
+      - name: Setup Gradle 7.1.1
+        uses: gradle/gradle-build-action@v2
+        with:
+          gradle-version: 7.1.1
+
       - name: Build JAR
         run: gradle clean bootJar
         

--- a/.github/workflows/protect-main.yml
+++ b/.github/workflows/protect-main.yml
@@ -12,6 +12,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Setup Gradle 7.1.1
+        uses: gradle/gradle-build-action@v2
+        with:
+          gradle-version: 7.1.1
+
       - name: Build JAR
         run: gradle clean build
 

--- a/src/main/java/com/github/sgov/server/controller/VocabularyController.java
+++ b/src/main/java/com/github/sgov/server/controller/VocabularyController.java
@@ -1,7 +1,8 @@
 package com.github.sgov.server.controller;
 
+import com.github.sgov.server.controller.dto.VocabularyDto;
 import com.github.sgov.server.controller.dto.VocabularyStatusDto;
-import com.github.sgov.server.controller.dto.VocabularyWorkspacesDto;
+import com.github.sgov.server.controller.dto.VocabularyWithWorkspacesDto;
 import com.github.sgov.server.service.repository.VocabularyRepositoryService;
 import com.github.sgov.server.util.Constants;
 import cz.cvut.kbss.jsonld.JsonLd;
@@ -42,7 +43,7 @@ public class VocabularyController extends BaseController {
     @GetMapping(produces = {
         MediaType.APPLICATION_JSON_VALUE, JsonLd.MEDIA_TYPE})
     @ApiOperation(value = "Retrieve all vocabularies.")
-    public List<VocabularyWorkspacesDto> findAll(@RequestHeader
+    public List<VocabularyWithWorkspacesDto> findAll(@RequestHeader
                                            Map<String, String> headers) {
         final String lang;
         lang = headers.getOrDefault("Accept-Language", "cs");

--- a/src/main/java/com/github/sgov/server/controller/VocabularyController.java
+++ b/src/main/java/com/github/sgov/server/controller/VocabularyController.java
@@ -1,7 +1,7 @@
 package com.github.sgov.server.controller;
 
-import com.github.sgov.server.controller.dto.VocabularyDto;
 import com.github.sgov.server.controller.dto.VocabularyStatusDto;
+import com.github.sgov.server.controller.dto.VocabularyWorkspacesDto;
 import com.github.sgov.server.service.repository.VocabularyRepositoryService;
 import com.github.sgov.server.util.Constants;
 import cz.cvut.kbss.jsonld.JsonLd;
@@ -42,11 +42,11 @@ public class VocabularyController extends BaseController {
     @GetMapping(produces = {
         MediaType.APPLICATION_JSON_VALUE, JsonLd.MEDIA_TYPE})
     @ApiOperation(value = "Retrieve all vocabularies.")
-    public List<VocabularyDto> findAll(@RequestHeader
+    public List<VocabularyWorkspacesDto> findAll(@RequestHeader
                                            Map<String, String> headers) {
         final String lang;
         lang = headers.getOrDefault("Accept-Language", "cs");
-        return vocabularyService.getVocabulariesAsContextDtos(lang);
+        return vocabularyService.getVocabulariesWithWorkspacesAsDtos(lang);
     }
 
     /**

--- a/src/main/java/com/github/sgov/server/controller/dto/VocabularyWithWorkspacesDto.java
+++ b/src/main/java/com/github/sgov/server/controller/dto/VocabularyWithWorkspacesDto.java
@@ -4,8 +4,10 @@ import cz.cvut.kbss.jsonld.annotation.JsonLdAttributeOrder;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 @Data
+@EqualsAndHashCode(callSuper = false)
 @JsonLdAttributeOrder({"uri", "label", "basedOnVersion", "changeTrackingContext", "inWorkspaces"})
 public class VocabularyWithWorkspacesDto extends VocabularyDto {
 
@@ -13,7 +15,7 @@ public class VocabularyWithWorkspacesDto extends VocabularyDto {
 
 
     /**
-     *  Adds workspace in which vocabulary is.
+     * Adds workspace in which vocabulary is.
      *
      * @param workspaceDto workspace DTO
      */

--- a/src/main/java/com/github/sgov/server/controller/dto/VocabularyWithWorkspacesDto.java
+++ b/src/main/java/com/github/sgov/server/controller/dto/VocabularyWithWorkspacesDto.java
@@ -6,8 +6,8 @@ import java.util.List;
 import lombok.Data;
 
 @Data
-@JsonLdAttributeOrder({"uri", "label", "basedOnVersion", "changeTrackingContext", "workspaces"})
-public class VocabularyWorkspacesDto extends VocabularyDto {
+@JsonLdAttributeOrder({"uri", "label", "basedOnVersion", "changeTrackingContext", "inWorkspaces"})
+public class VocabularyWithWorkspacesDto extends VocabularyDto {
 
     List<WorkspaceDto> inWorkspaces;
 
@@ -29,7 +29,7 @@ public class VocabularyWorkspacesDto extends VocabularyDto {
      *
      * @param vocabularyDto reference DTO
      */
-    public VocabularyWorkspacesDto(VocabularyDto vocabularyDto) {
+    public VocabularyWithWorkspacesDto(VocabularyDto vocabularyDto) {
         this.setUri(vocabularyDto.getUri());
         this.setTypes(vocabularyDto.getTypes());
         this.setLabel(vocabularyDto.getLabel());

--- a/src/main/java/com/github/sgov/server/controller/dto/VocabularyWorkspacesDto.java
+++ b/src/main/java/com/github/sgov/server/controller/dto/VocabularyWorkspacesDto.java
@@ -1,0 +1,38 @@
+package com.github.sgov.server.controller.dto;
+
+import cz.cvut.kbss.jsonld.annotation.JsonLdAttributeOrder;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Data;
+
+@Data
+@JsonLdAttributeOrder({"uri", "label", "basedOnVersion", "changeTrackingContext", "workspaces"})
+public class VocabularyWorkspacesDto extends VocabularyDto {
+
+    List<WorkspaceDto> inWorkspaces;
+
+
+    /**
+     *  Adds workspace in which vocabulary is.
+     *
+     * @param workspaceDto workspace DTO
+     */
+    public void addInWorkspace(WorkspaceDto workspaceDto) {
+        if (inWorkspaces == null) {
+            inWorkspaces = new ArrayList<>();
+        }
+        inWorkspaces.add(workspaceDto);
+    }
+
+    /**
+     * Creates VocabularyWorkspacesDto from VocabularyDto.
+     *
+     * @param vocabularyDto reference DTO
+     */
+    public VocabularyWorkspacesDto(VocabularyDto vocabularyDto) {
+        this.setUri(vocabularyDto.getUri());
+        this.setTypes(vocabularyDto.getTypes());
+        this.setLabel(vocabularyDto.getLabel());
+        this.setChangeTrackingContext(vocabularyDto.getChangeTrackingContext());
+    }
+}

--- a/src/main/java/com/github/sgov/server/controller/dto/WorkspaceDto.java
+++ b/src/main/java/com/github/sgov/server/controller/dto/WorkspaceDto.java
@@ -1,0 +1,24 @@
+package com.github.sgov.server.controller.dto;
+
+import cz.cvut.kbss.jopa.model.annotations.Id;
+import cz.cvut.kbss.jopa.model.annotations.OWLAnnotationProperty;
+import cz.cvut.kbss.jopa.vocabulary.DC;
+import cz.cvut.kbss.jsonld.annotation.JsonLdAttributeOrder;
+import java.net.URI;
+import lombok.Data;
+
+@Data
+@JsonLdAttributeOrder({"uri", "label"})
+public class WorkspaceDto {
+
+    @Id
+    private URI uri;
+
+    @OWLAnnotationProperty(iri = DC.Terms.TITLE)
+    private String label;
+
+    public WorkspaceDto(URI uri, String label) {
+        this.uri = uri;
+        this.label = label;
+    }
+}

--- a/src/main/java/com/github/sgov/server/controller/dto/WorkspaceDto.java
+++ b/src/main/java/com/github/sgov/server/controller/dto/WorkspaceDto.java
@@ -1,7 +1,9 @@
 package com.github.sgov.server.controller.dto;
 
+import com.github.sgov.server.util.Vocabulary;
 import cz.cvut.kbss.jopa.model.annotations.Id;
 import cz.cvut.kbss.jopa.model.annotations.OWLAnnotationProperty;
+import cz.cvut.kbss.jopa.model.annotations.OWLClass;
 import cz.cvut.kbss.jopa.vocabulary.DC;
 import cz.cvut.kbss.jsonld.annotation.JsonLdAttributeOrder;
 import java.net.URI;
@@ -9,6 +11,7 @@ import lombok.Data;
 
 @Data
 @JsonLdAttributeOrder({"uri", "label"})
+@OWLClass(iri = Vocabulary.s_c_metadatovy_kontext)
 public class WorkspaceDto {
 
     @Id

--- a/src/main/java/com/github/sgov/server/service/repository/VocabularyRepositoryService.java
+++ b/src/main/java/com/github/sgov/server/service/repository/VocabularyRepositoryService.java
@@ -158,7 +158,8 @@ public class VocabularyRepositoryService extends BaseRepositoryService<Vocabular
                     repositoryConf.getUrl()));
             final RepositoryConnection connection = repo.getConnection();
             getVocabulariesAsContextDtos(lang).forEach(vocabularyDto -> {
-                final VocabularyWithWorkspacesDto vWDto = new VocabularyWithWorkspacesDto(vocabularyDto);
+                final VocabularyWithWorkspacesDto vWDto =
+                        new VocabularyWithWorkspacesDto(vocabularyDto);
                 connection.prepareTupleQuery("SELECT DISTINCT ?uri ?label WHERE {"
                     + "?uri a <" + Vocabulary.s_c_metadatovy_kontext + "> ;"
                     + " <" + DCTERMS.TITLE + "> ?label ;"

--- a/src/main/java/com/github/sgov/server/service/repository/VocabularyRepositoryService.java
+++ b/src/main/java/com/github/sgov/server/service/repository/VocabularyRepositoryService.java
@@ -6,7 +6,7 @@ import com.github.sgov.server.config.conf.RepositoryConf;
 import com.github.sgov.server.controller.dto.VocabularyContextDto;
 import com.github.sgov.server.controller.dto.VocabularyDto;
 import com.github.sgov.server.controller.dto.VocabularyStatusDto;
-import com.github.sgov.server.controller.dto.VocabularyWorkspacesDto;
+import com.github.sgov.server.controller.dto.VocabularyWithWorkspacesDto;
 import com.github.sgov.server.controller.dto.WorkspaceDto;
 import com.github.sgov.server.dao.VocabularyDao;
 import com.github.sgov.server.dao.WorkspaceDao;
@@ -150,15 +150,15 @@ public class VocabularyRepositoryService extends BaseRepositoryService<Vocabular
      * @param lang language to fetch the label in
      * @return vocabularies in the form of vocabulary context
      */
-    public List<VocabularyWorkspacesDto> getVocabulariesWithWorkspacesAsDtos(String lang) {
-        List<VocabularyWorkspacesDto> contexts = new ArrayList<>();
+    public List<VocabularyWithWorkspacesDto> getVocabulariesWithWorkspacesAsDtos(String lang) {
+        List<VocabularyWithWorkspacesDto> contexts = new ArrayList<>();
         try {
             final SPARQLRepository repo =
                 new SPARQLRepository(IdnUtils.convertUnicodeUrlToAscii(
                     repositoryConf.getUrl()));
             final RepositoryConnection connection = repo.getConnection();
             getVocabulariesAsContextDtos(lang).forEach(vocabularyDto -> {
-                final VocabularyWorkspacesDto vWDto = new VocabularyWorkspacesDto(vocabularyDto);
+                final VocabularyWithWorkspacesDto vWDto = new VocabularyWithWorkspacesDto(vocabularyDto);
                 connection.prepareTupleQuery("SELECT DISTINCT ?uri ?label WHERE {"
                     + "?uri a <" + Vocabulary.s_c_metadatovy_kontext + "> ;"
                     + " <" + DCTERMS.TITLE + "> ?label ;"

--- a/src/main/java/com/github/sgov/server/service/repository/VocabularyRepositoryService.java
+++ b/src/main/java/com/github/sgov/server/service/repository/VocabularyRepositoryService.java
@@ -6,6 +6,8 @@ import com.github.sgov.server.config.conf.RepositoryConf;
 import com.github.sgov.server.controller.dto.VocabularyContextDto;
 import com.github.sgov.server.controller.dto.VocabularyDto;
 import com.github.sgov.server.controller.dto.VocabularyStatusDto;
+import com.github.sgov.server.controller.dto.VocabularyWorkspacesDto;
+import com.github.sgov.server.controller.dto.WorkspaceDto;
 import com.github.sgov.server.dao.VocabularyDao;
 import com.github.sgov.server.dao.WorkspaceDao;
 import com.github.sgov.server.exception.SGoVException;
@@ -123,21 +125,58 @@ public class VocabularyRepositoryService extends BaseRepositoryService<Vocabular
                     + ((lang != null) ? "FILTER (lang(?label)='" + lang + "')" : "")
                     + " }} ORDER BY ?label");
             final Set<URI> uris = getWriteLockedVocabularies();
-            query.evaluate().forEach(b -> {
-                final VocabularyDto c = new VocabularyDto();
-                final URI uri = URI.create(b.getValue("g").stringValue());
-                c.setBasedOnVersion(uri);
-                c.setReadonly(uris.contains(uri));
-                if (b.hasBinding("label")) {
-                    c.setLabel(b.getValue("label").stringValue());
+            query.evaluate().forEach(res -> {
+                final VocabularyDto vDto = new VocabularyDto();
+                final URI uri = URI.create(res.getValue("g").stringValue());
+                vDto.setUri(uri);
+                vDto.setBasedOnVersion(uri);
+                vDto.setReadonly(uris.contains(uri));
+                if (res.hasBinding("label")) {
+                    vDto.setLabel(res.getValue("label").stringValue());
                 }
-                contexts.add(c);
+                contexts.add(vDto);
             });
             connection.close();
             return contexts;
         } catch (URISyntaxException e) {
             throw new SGoVException(e);
         }
+    }
+
+    /**
+     * Finds all vocabularies which are published with optional label in the given language.
+     * Each vocabulary is enriched with list of workspaces the vocabulary is in.
+     *
+     * @param lang language to fetch the label in
+     * @return vocabularies in the form of vocabulary context
+     */
+    public List<VocabularyWorkspacesDto> getVocabulariesWithWorkspacesAsDtos(String lang) {
+        List<VocabularyWorkspacesDto> contexts = new ArrayList<>();
+        try {
+            final SPARQLRepository repo =
+                new SPARQLRepository(IdnUtils.convertUnicodeUrlToAscii(
+                    repositoryConf.getUrl()));
+            final RepositoryConnection connection = repo.getConnection();
+            getVocabulariesAsContextDtos(lang).forEach(vocabularyDto -> {
+                final VocabularyWorkspacesDto vWDto = new VocabularyWorkspacesDto(vocabularyDto);
+                connection.prepareTupleQuery("SELECT DISTINCT ?uri ?label WHERE {"
+                    + "?uri a <" + Vocabulary.s_c_metadatovy_kontext + "> ;"
+                    + " <" + DCTERMS.TITLE + "> ?label ;"
+                    + " <" + Vocabulary.s_p_odkazuje_na_kontext + "> ["
+                    + "  <" + Vocabulary.s_p_vychazi_z_verze + "> <" + vocabularyDto.getUri() + ">"
+                    + " ] . }").evaluate().forEach(res -> {
+                        URI wsUri = URI.create(res.getValue("uri").stringValue());
+                        String label = res.getValue("label").stringValue();
+                        vWDto.addInWorkspace(new WorkspaceDto(wsUri, label));
+                    }
+                );
+                contexts.add(vWDto);
+            });
+            connection.close();
+        } catch (URISyntaxException e) {
+            throw new SGoVException(e);
+        }
+        return contexts;
     }
 
     /**


### PR DESCRIPTION
Changes the data transfer object on get all vocabularies endpoint to contain URI and label of workspaces in which the vocabulary is present.
Closes #160 