### PR TITLE
Don't copy gestore users to VocabularyContexts

### DIFF
--- a/src/main/java/com/github/sgov/server/service/repository/VocabularyRepositoryService.java
+++ b/src/main/java/com/github/sgov/server/service/repository/VocabularyRepositoryService.java
@@ -159,7 +159,7 @@ public class VocabularyRepositoryService extends BaseRepositoryService<Vocabular
             final RepositoryConnection connection = repo.getConnection();
             getVocabulariesAsContextDtos(lang).forEach(vocabularyDto -> {
                 final VocabularyWithWorkspacesDto vWDto =
-                        new VocabularyWithWorkspacesDto(vocabularyDto);
+                    new VocabularyWithWorkspacesDto(vocabularyDto);
                 connection.prepareTupleQuery("SELECT DISTINCT ?uri ?label WHERE {"
                     + "?uri a <" + Vocabulary.s_c_metadatovy_kontext + "> ;"
                     + " <" + DCTERMS.TITLE + "> ?label ;"
@@ -357,7 +357,8 @@ public class VocabularyRepositoryService extends BaseRepositoryService<Vocabular
                 + version
                 + ">" + ((context instanceof VocabularyContext)
                 ? ",:glosář,:model,:mapování,:přílohy" : "")
-                + "))}");
+                + "))"
+                + "FILTER(?p != <" + Vocabulary.s_p_ma_gestora + ">)}");
         return query.evaluate();
     }
 

--- a/src/main/java/com/github/sgov/server/util/Vocabulary.java
+++ b/src/main/java/com/github/sgov/server/util/Vocabulary.java
@@ -17,6 +17,8 @@ public final class Vocabulary {
         "https://slovník.gov.cz/datový/pracovní-prostor/pojem/";
     public static final String DATA_DESCRIPTION_NAMESPACE =
         "http://onto.fel.cvut.cz/ontologies/slovník/agendový/popis-dat/pojem/";
+    public static final String CHANGE_DESCRIPTION_NAMESPACE =
+        "https://slovník.gov.cz/datový/popis-zmen/pojem/";
 
     public static final String s_c_metadatovy_kontext = WORKSPACE_NAMESPACE + "metadatový-kontext";
     public static final String s_c_prilohovy_kontext = WORKSPACE_NAMESPACE + "přílohový-kontext";
@@ -78,6 +80,8 @@ public final class Vocabulary {
 
     public static final String version_separator = "/verze/";
     public static final String postfix_kontextu_sledovani_zmen = "/změny";
+    public static final String s_p_ma_gestora = CHANGE_DESCRIPTION_NAMESPACE
+        + "má-gestora";
 
     private Vocabulary() {
     }


### PR DESCRIPTION
When creating a vocabulary context, gestors assigned to vocabulary are not copied.